### PR TITLE
Allow async-await rule to pass with "return fnAsync()"

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,14 @@ const fooAsync = function() {}
 ```
 
 ### async-await
-This rule enforces that all functions with an `Async` suffix on their name should be called with an `await`. Functions without the suffix should not be called with an `await`.
+This rule enforces that all functions with an `Async` suffix on their name should be called with an `await` or `return`. Functions without the suffix should not be called with an `await` or `return`.
 
 There are times when you may wish for an `async` function to run in the background, or where you need to call 3rd party code that doesn't follow the `async-suffix` naming convention. In that case use `// eslint-disable-line async-protect/async-await` to disable the rule for that line.
 
 ##### valid
 ```
 await fooAsync();
+return fooAsync();
 const result = await fooAsync();
 const result = (await fooAsync()).result;
 const result = await foo().bar().bazAsync();
@@ -80,7 +81,7 @@ const result = foo();
 
 ##### invalid
 ```
-await fooAsync();
+fooAsync();
 const result = fooAsync();
 const result = fooAsync().result;
 const result = foo().bar().bazAsync();

--- a/src/async-await.js
+++ b/src/async-await.js
@@ -44,6 +44,11 @@ module.exports = {
             return node.parent.type === "AwaitExpression";
         };
 
+        const isReturned = (node) => {
+            // Immediate parent is "return" so we are returning
+            return node.parent.type === 'ReturnStatement';
+        };
+
         const CallExpression = (node) => {
             // Grab the IdentifierNode. If this isn't a pattern
             // we know about just abort
@@ -54,9 +59,10 @@ module.exports = {
 
             // Were async functions called with an await?
             const calledWithAwait = isAwaited(node);
+            const calledWithReturn = isReturned(node);
             const nameEndsWithAsync = endsWithAsync(idNode.name);
 
-            if (nameEndsWithAsync && !calledWithAwait) {
+            if (nameEndsWithAsync && !calledWithAwait && !calledWithReturn) {
                 context.report({
                     node: node,
                     message: MISSING_AWAIT,

--- a/tests/rules/async-await.js
+++ b/tests/rules/async-await.js
@@ -37,6 +37,18 @@ ruleTester.run("async-await", rule, {
         {
             code: `
                 (iife = async function() {
+                    return fooAsync();
+                })();`
+        },
+        {
+            code: `
+                (iife = async function() {
+                    return await fooAsync();
+                })();`
+        },
+        {
+            code: `
+                (iife = async function() {
                     foo();
                 })();`
         },
@@ -109,7 +121,23 @@ ruleTester.run("async-await", rule, {
         {
             code: `
                 (iife = async function() {
+                    fooAsync();
+                    return;
+                })();`,
+            errors: [{ message: getError("fooAsync", true), type: "CallExpression" }],
+        },
+        {
+            code: `
+                (iife = async function() {
                     await foo();
+                })();`,
+            errors: [{ message: getError("foo", false), type: "CallExpression" }],
+        },
+        {
+            code: `
+                (iife = async function() {
+                    await foo();
+                    return;
                 })();`,
             errors: [{ message: getError("foo", false), type: "CallExpression" }],
         },


### PR DESCRIPTION
resolves #3

This allows the following scenarios to pass:

```
async fn1Async(a) {
   // change in rule behavior - this would not pass before
   return runner.fn2Async(a);
}

async fn1Async(a) {
   // no change in rule behavior
   await runner.fn2Async(a);
}

async fn1Async(a) {
   // no change in rule behavior
   // return await is 100% unnecessary and bad for performance, but still valid
   return await runner.fn2Async(a);
}
```