### PR TITLE
Fix shorthand property definitions

### DIFF
--- a/src/async-suffix.js
+++ b/src/async-suffix.js
@@ -111,6 +111,11 @@ module.exports = {
             const identifier = node.key;
             const functionExpression = node.value;
 
+            // Ignore shorthand node definitions
+            if (node.shorthand) {
+                return;
+            }
+
             if (identifier && functionExpression) {
                 check(node, identifier, functionExpression.async);
             }

--- a/tests/rules/async-suffix.js
+++ b/tests/rules/async-suffix.js
@@ -103,6 +103,16 @@ ruleTester.run("async-suffix", rule, {
         {
             code: `ngOnInit = async function() { };`,
         },
+        {
+            code: `(iifeAsync = async function() {
+                     const updateItemAsync = async function() {};
+                     return { updateItemAsync };
+                   });`,
+        },
+        {
+            code: `async function updateItemAsync() {};
+                   module.exports = { updateItemAsync };`,
+        },
     ],
 
     invalid: [


### PR DESCRIPTION
Fixes #6 by suppressing the `async` suffix when dealing with shorthand property names.