### PR TITLE
feat: consider function as async if return type is promise

### DIFF
--- a/src/async-suffix.js
+++ b/src/async-suffix.js
@@ -27,6 +27,10 @@ module.exports = {
 
         const endsWithAsync = (name) => name.endsWith("Async");
 
+        const isReturningPromise = (node) => {
+            return node.value?.body?.body?.[0]?.argument?.callee?.name === 'Promise';
+        };
+
         /**
          * Check a node is valid
          * @param  {Object}  node       The root node that is being checked
@@ -86,7 +90,7 @@ module.exports = {
             const functionExpression = node.value;
 
             if (identifier && functionExpression) {
-                check(node, identifier, functionExpression.async);
+                check(node, identifier, functionExpression.async || isReturningPromise(node));
             }
         };
 
@@ -94,7 +98,7 @@ module.exports = {
             const identifier = node.id;
 
             if (identifier) {
-                check(node, identifier, node.async);
+                check(node, identifier, node.async || isReturningPromise(node));
             }
         };
 

--- a/tests/rules/async-suffix.js
+++ b/tests/rules/async-suffix.js
@@ -47,6 +47,12 @@ ruleTester.run("async-suffix", rule, {
                    }`,
         },
         {
+            code: `class Foo {
+                       fooAsync() { return new Promise((resolve) => resolve()); }
+                       foo() {}
+                   }`,
+        },
+        {
             code: `const obj = {
                        async fooAsync() {},
                        foo() {}
@@ -143,6 +149,13 @@ ruleTester.run("async-suffix", rule, {
         {
             code: `class Foo {
                        async foo() { }
+                       fooAsync() {}
+                   }`,
+            errors: [getMethodError("foo", true), getMethodError("foo", false)],
+        },
+        {
+            code: `class Foo {
+                       foo() { return new Promise((resolve) => resolve()); }
                        fooAsync() {}
                    }`,
             errors: [getMethodError("foo", true), getMethodError("foo", false)],


### PR DESCRIPTION
The only way to create a method to return a new promise before this PR was to await the promise and make it async again
```
  public static async timeoutAsync(ms: number): Promise<void> {
    return await new Promise((resolve) => {
      setTimeout(resolve, ms);
    });
  }
```


but with these changes, this code would be allowed too:
```
  public static timeoutAsync(ms: number): Promise<void> {
    return new Promise((resolve) => {
      setTimeout(resolve, ms);
    });
  }
```