### PR TITLE
chore: allow newer eslint versions as peer depencency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "mocha tests --recursive"
   },
   "peerDependencies": {
-    "eslint": "^5.0.0"
+    "eslint": "5 - 8"
   },
   "devDependencies": {
     "eslint": "~5.0.0",


### PR DESCRIPTION
We've tested this library with latest versions of ESlint for a few month's and it has been totally compatible.